### PR TITLE
slug collision prevention

### DIFF
--- a/migrations/Version20231030022628.php
+++ b/migrations/Version20231030022628.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20231030022628 extends AbstractMigration
+{
+    public function getDescription() : string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_D8F0A91E989D9B62 ON trick (slug)');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('DROP INDEX UNIQ_D8F0A91E989D9B62 ON trick');
+    }
+}

--- a/src/Entity/Trick.php
+++ b/src/Entity/Trick.php
@@ -92,7 +92,7 @@ class Trick
 
     /**
      * @var string $slug The slug converted string from trick's name
-     * @ORM\Column(type="string", length=255)
+     * @ORM\Column(type="string", length=255, unique=true)
      */
     private $slug;
 


### PR DESCRIPTION
Prevent an eventual slug collision by a constraint of unicity on the slug field in the trick table and the management of the risk in trick creation and update methods